### PR TITLE
Additives cacheing complete

### DIFF
--- a/app/src/main/java/com/example/healthinspector/Fragments/HomeFragment.java
+++ b/app/src/main/java/com/example/healthinspector/Fragments/HomeFragment.java
@@ -28,7 +28,6 @@ import com.android.volley.RequestQueue;
 import com.android.volley.toolbox.JsonObjectRequest;
 import com.android.volley.toolbox.Volley;
 import com.example.healthinspector.Adapters.KrogerLocationAdapter;
-import com.example.healthinspector.Cache.CachedLists;
 import com.example.healthinspector.Constants;
 import com.example.healthinspector.CreateRecommendations;
 import com.example.healthinspector.FragmentSwitch;
@@ -207,21 +206,23 @@ public class HomeFragment extends Fragment implements OnMapReadyCallback {
         return newLocation;
     }
     public void notifyClosestStore() throws JSONException {
-        JSONObject closestLocationObject = locations.get(0);
-        Location closestLocation = new Location("");
-        closestLocation.setLongitude(closestLocationObject.getDouble(Constants.LONGITUDE));
-        closestLocation.setLatitude(closestLocationObject.getDouble(Constants.LATITUDE));
-        NotificationCompat.Builder builder = new NotificationCompat.Builder(requireContext(), Constants.CHANNEL_ID);
-        NotificationManager mNotificationManager = (NotificationManager) requireActivity().getSystemService(Context.NOTIFICATION_SERVICE);
-        PendingIntent pendingQuitIntent = PendingIntent.getBroadcast(requireContext(), (int) System.currentTimeMillis(), new Intent(Constants.QUIT_ACTION), PendingIntent.FLAG_MUTABLE);
-        mNotificationManager.notify(1, builder.setContentTitle(getText(R.string.notification_title))
-                .setContentText(String.format(NOTIFICATION_MESSAGE, closestLocationObject.getString(Constants.STORE_NAME), lastLocation.distanceTo(closestLocation)))
-                .setSmallIcon(R.drawable.health_inspector_logo_1)
-                .addAction(R.drawable.health_inspector_logo_1, getText(R.string.notification_quit_button),
-                        pendingQuitIntent)
-                .setAutoCancel(true)
-                .setOnlyAlertOnce(true)
-                .build());
+        if(locations.size() > 0){
+            JSONObject closestLocationObject = locations.get(0);
+            Location closestLocation = new Location("");
+            closestLocation.setLongitude(closestLocationObject.getDouble(Constants.LONGITUDE));
+            closestLocation.setLatitude(closestLocationObject.getDouble(Constants.LATITUDE));
+            NotificationCompat.Builder builder = new NotificationCompat.Builder(requireContext(), Constants.CHANNEL_ID);
+            NotificationManager mNotificationManager = (NotificationManager) requireActivity().getSystemService(Context.NOTIFICATION_SERVICE);
+            PendingIntent pendingQuitIntent = PendingIntent.getBroadcast(requireContext(), (int) System.currentTimeMillis(), new Intent(Constants.QUIT_ACTION), PendingIntent.FLAG_MUTABLE);
+            mNotificationManager.notify(1, builder.setContentTitle(getText(R.string.notification_title))
+                    .setContentText(String.format(NOTIFICATION_MESSAGE, closestLocationObject.getString(Constants.STORE_NAME), lastLocation.distanceTo(closestLocation)))
+                    .setSmallIcon(R.drawable.health_inspector_logo_1)
+                    .addAction(R.drawable.health_inspector_logo_1, getText(R.string.notification_quit_button),
+                            pendingQuitIntent)
+                    .setAutoCancel(true)
+                    .setOnlyAlertOnce(true)
+                    .build());
+        }
     }
 }
 

--- a/app/src/main/java/com/example/healthinspector/Models/Additive.java
+++ b/app/src/main/java/com/example/healthinspector/Models/Additive.java
@@ -4,14 +4,13 @@ import com.parse.ParseObject;
 
 @ParseClassName("Additives")
 public class Additive extends ParseObject {
-    private static final String ADDITIVE_KEY = "additiveKey";
-    private static final String ADDITIVE_VALUE = "additiveValue";
-    private static final String ADDITIVE_USES_KEY = "uses";
-    public static final String USES_KEY = "uses";
+    public static final String ADDITIVE_USES_KEY = "uses";
+    public static final String ADDITIVE_KEY = "additiveKey";
+    public static final String ADDITIVE_VALUE = "additiveValue";
 
     public Additive(){}
     public String getAdditiveKey(){return getString(ADDITIVE_KEY);}
     public String getAdditiveValue(){return getString(ADDITIVE_VALUE);}
     public void setAdditiveUsage(int uses){put(ADDITIVE_USES_KEY, uses);}
-    public void getAdditiveUsage(){getInt(ADDITIVE_VALUE);}
+    public int getAdditiveUsage(){return getInt(ADDITIVE_USES_KEY);}
 }


### PR DESCRIPTION
- When users add or remove additives to their profiles, the respective additive's usage field on the database gets updated
- When user searches for additives that are not in the top 50 most used additives (that are cached locally) the database is checked for anything that may match their search text
- Improved Jackson usage, now uses a LinkedHashMap to maintain the order received from the database (descending order filter on additive usage)